### PR TITLE
Fix TypeScript capitalization

### DIFF
--- a/plugin.template.xml
+++ b/plugin.template.xml
@@ -1,11 +1,11 @@
 <idea-plugin>
   <id>com.lukasbach.intellij.snippets.typescriptreact</id>
-  <name>Live Templates for Typescript and React</name>
+  <name>Live Templates for TypeScript and React</name>
   <!-- The <version> of this plugin is set by patchPluginXml.version in build.gradle -->
   <vendor email="lbach@outlook.de" url="https://lukasbach.com">Lukas Bach</vendor>
 
   <description><![CDATA[
-      <p>Live templates for Typescript and React, including React hooks!</p>
+      <p>Live templates for TypeScript and React, including React hooks!</p>
 
       <p>Currently supported:</p>
 

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,13 @@
-# IntelliJ Live Templates for Typescript and React
+# IntelliJ Live Templates for TypeScript and React
 
-[![Download](https://img.shields.io/badge/Get-from%20Jetbrains%20Marketplace-brightgreen)](https://plugins.jetbrains.com/plugin/16796-live-templates-for-typescript-and-react)
+[![Download](https://img.shields.io/badge/Get-from%20JetBrains%20Marketplace-brightgreen)](https://plugins.jetbrains.com/plugin/16796-live-templates-for-typescript-and-react)
 [![Build and verify](https://github.com/lukasbach/intellij-ts-react-livetemplates/actions/workflows/verify.yml/badge.svg)](https://github.com/lukasbach/intellij-ts-react-livetemplates/actions/workflows/verify.yml)
 [![Deploy](https://github.com/lukasbach/intellij-ts-react-livetemplates/actions/workflows/deploy.yml/badge.svg)](https://github.com/lukasbach/intellij-ts-react-livetemplates/actions/workflows/deploy.yml)
 ![JetBrains plugins](https://img.shields.io/jetbrains/plugin/d/16796)
 ![JetBrains Plugins](https://img.shields.io/jetbrains/plugin/r/rating/16796)
 
-Live templates for Typescript and typed React code, for IntelliJ Idea, 
-Webstorm, PHPStorm and other Jetbrains IDEs. With sensible variable
+Live templates for TypeScript and typed React code, for IntelliJ IDEA,
+WebStorm, PHPStorm and other JetBrains IDEs. With sensible variable
 expressions and useful skeleton templates.
 
 Supported templates:
@@ -18,8 +18,8 @@ Supported templates:
 - `rfc`: _React Functional Component_
 - `rfct`: _React typed Functional Component_
 - `rfr`: _React forward Ref_
-- `int`: _Typescript Interface_
-- `type`: _Typescript Type_
+- `int`: _TypeScript Interface_
+- `type`: _TypeScript Type_
 - `arr`: _Anonymous arrow function_
 - `el`: _JSX element_
 - `rcctx`: _React create new Context with type, hook and provider_
@@ -154,7 +154,7 @@ Variables:
 |`PROPS`|`-`|{}|false|
 |`INNER_COMP`|`completeSmart()`||false|
 
-### Typescript Interface
+### TypeScript Interface
 
 Invoked via `int`.
 
@@ -169,7 +169,7 @@ Variables:
 |----|----------|-------------|---------------|
 |`1`|`-`||false|
 
-### Typescript Type
+### TypeScript Type
 
 Invoked via `type`.
 

--- a/readme.template.md
+++ b/readme.template.md
@@ -1,13 +1,13 @@
-# IntelliJ Live Templates for Typescript and React
+# IntelliJ Live Templates for TypeScript and React
 
-[![Download](https://img.shields.io/badge/Get-from%20Jetbrains%20Marketplace-brightgreen)](https://plugins.jetbrains.com/plugin/16796-live-templates-for-typescript-and-react)
+[![Download](https://img.shields.io/badge/Get-from%20JetBrains%20Marketplace-brightgreen)](https://plugins.jetbrains.com/plugin/16796-live-templates-for-typescript-and-react)
 [![Build and verify](https://github.com/lukasbach/intellij-ts-react-livetemplates/actions/workflows/verify.yml/badge.svg)](https://github.com/lukasbach/intellij-ts-react-livetemplates/actions/workflows/verify.yml)
 [![Deploy](https://github.com/lukasbach/intellij-ts-react-livetemplates/actions/workflows/deploy.yml/badge.svg)](https://github.com/lukasbach/intellij-ts-react-livetemplates/actions/workflows/deploy.yml)
 ![JetBrains plugins](https://img.shields.io/jetbrains/plugin/d/16796)
 ![JetBrains Plugins](https://img.shields.io/jetbrains/plugin/r/rating/16796)
 
-Live templates for Typescript and typed React code, for IntelliJ Idea, 
-Webstorm, PHPStorm and other Jetbrains IDEs. With sensible variable
+Live templates for TypeScript and typed React code, for IntelliJ IDEA,
+WebStorm, PHPStorm and other JetBrains IDEs. With sensible variable
 expressions and useful skeleton templates.
 
 Supported templates:

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,15 +1,15 @@
 <idea-plugin>
   <id>com.lukasbach.intellij.snippets.typescriptreact</id>
-  <name>Live Templates for Typescript and React</name>
+  <name>Live Templates for TypeScript and React</name>
   <!-- The <version> of this plugin is set by patchPluginXml.version in build.gradle -->
   <vendor email="lbach@outlook.de" url="https://lukasbach.com">Lukas Bach</vendor>
 
   <description><![CDATA[
-      <p>Live templates for Typescript and React, including React hooks!</p>
+      <p>Live templates for TypeScript and React, including React hooks!</p>
 
       <p>Currently supported:</p>
 
-      
+
 <li><tt>uses</tt>: <em>React.useState()</em></li>
 
 <li><tt>usee</tt>: <em>React.useEffect()</em></li>
@@ -22,9 +22,9 @@
 
 <li><tt>rfr</tt>: <em>React forward Ref</em></li>
 
-<li><tt>int</tt>: <em>Typescript Interface</em></li>
+<li><tt>int</tt>: <em>TypeScript Interface</em></li>
 
-<li><tt>type</tt>: <em>Typescript Type</em></li>
+<li><tt>type</tt>: <em>TypeScript Type</em></li>
 
 <li><tt>arr</tt>: <em>Anonymous arrow function</em></li>
 

--- a/src/main/resources/templates/TypedReact.xml
+++ b/src/main/resources/templates/TypedReact.xml
@@ -55,13 +55,13 @@
             <option name="JS_TOP_LEVEL_STATEMENT" value="true" />
         </context>
     </template>
-    <template name="int" value="export interface $1$ {&#10;    $END$&#10;}" description="Typescript Interface" toReformat="true" toShortenFQNames="true">
+    <template name="int" value="export interface $1$ {&#10;    $END$&#10;}" description="TypeScript Interface" toReformat="true" toShortenFQNames="true">
         <variable name="1" expression="" defaultValue="" alwaysStopAt="true" />
         <context>
             <option name="TS_TOP_LEVEL_STATEMENT" value="true" />
         </context>
     </template>
-    <template name="type" value="export type $1$ = {&#10;    $END$&#10;}" description="Typescript Type" toReformat="true" toShortenFQNames="true">
+    <template name="type" value="export type $1$ = {&#10;    $END$&#10;}" description="TypeScript Type" toReformat="true" toShortenFQNames="true">
         <variable name="1" expression="" defaultValue="" alwaysStopAt="true" />
         <context>
             <option name="TS_TOP_LEVEL_STATEMENT" value="true" />


### PR DESCRIPTION
A few minor capitalization fixes, e.g. `Typescript` -> `TypeScript`.

Thanks for this plugin!